### PR TITLE
Take the extension dot into account when stripping extension from filenames

### DIFF
--- a/packages/react-file-manager-ctz/src/components/file-list/FileEntry-hooks.tsx
+++ b/packages/react-file-manager-ctz/src/components/file-list/FileEntry-hooks.tsx
@@ -102,7 +102,7 @@ export const useFileNameComponent = (file: Nullable<FileData>) => {
       name = file.name;
     } else {
       extension = file.ext ?? _extname(file.name);
-      name = file.name.substring(0, file.name.length - extension.length);
+      name = file.name.substring(0, file.name.length - (extension.length + 1));
     }
 
     if (name.length > 45) {


### PR DESCRIPTION
The extension dot is currently rendered twice:
![image](https://github.com/user-attachments/assets/2aa55f67-d717-4929-883a-ea426eaa8b90)

This fix ensures it is only rendered once
![image](https://github.com/user-attachments/assets/bade6663-74e7-43b4-bfd1-ec51a2cf7f39)
